### PR TITLE
A couple more tests

### DIFF
--- a/GitTfsTest/Core/ChangeSieveTests.cs
+++ b/GitTfsTest/Core/ChangeSieveTests.cs
@@ -493,6 +493,13 @@ namespace Sep.Git.Tfs.Test.Core
             {
                 Assert.Equal(0, Subject.GetChangesToApply().Count());
             }
+
+            [Fact]
+            public void DoNotFetch()
+            {
+                // Because we're not going to apply changes, don't waste time fetching any.
+                Assert.Equal(0, Subject.GetChangesToFetch().Count());
+            }
         }
 
         public class WithDeleteOtherFolder : Base<WithDeleteOtherFolder.Fixture>
@@ -516,6 +523,12 @@ namespace Sep.Git.Tfs.Test.Core
             {
                 AssertChanges(Subject.GetChangesToApply(),
                     ApplicableChange.Update("file1.txt"));
+            }
+
+            [Fact]
+            public void FetchesChangesInThisProject()
+            {
+                Assert.Equal(new string[] { "$/Project/file1.txt" }, Subject.GetChangesToFetch().Select(c => c.Item.ServerItem));
             }
         }
     }


### PR DESCRIPTION
I was curious about a couple of things:
- When ChangeSieve forces there to be no changes to apply, does it also force there to be no changes to fetch?
- Is the "deleted a directory" check correct? In other words, does it treat deleting `$/OtherProject` the same (or different) as deleting `$/Project`.

This branch make the `Fetch` be empty in the "delete the whole directory" case. This branch also adds a test to ensure that the check for deleting `$/Project` doesn't also pick up other directories outside of the project.
