### PR TITLE
[WIP] Fix for GetPathInGitRepo and substrings

### DIFF
--- a/GitTfs/Core/DerivedGitTfsRemote.cs
+++ b/GitTfs/Core/DerivedGitTfsRemote.cs
@@ -195,7 +195,17 @@ namespace Sep.Git.Tfs.Core
             throw DerivedRemoteException;
         }
 
-        public string GetPathInGitRepo(string tfsPath)
+        public IGitTfsRemote InitBranch(RemoteOptions remoteOptions, string tfsRepositoryPath, long shaRootChangesetId, bool fetchParentBranch, string gitBranchNameExpected = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool FindChangeSetInGitRepo(IChangeset changeset)
+        {
+            throw DerivedRemoteException;
+        }
+
+        public string GetPathInGitRepo(string tfsPath, bool includeTrailingSlash = false)
         {
             throw DerivedRemoteException;
         }

--- a/GitTfs/Core/TfsInterop/ITfsHelper.cs
+++ b/GitTfs/Core/TfsInterop/ITfsHelper.cs
@@ -30,7 +30,7 @@ namespace Sep.Git.Tfs.Core.TfsInterop
         IEnumerable<TfsLabel> GetLabels(string tfsPathBranch, string nameFilter = null);
         bool CanGetBranchInformation { get; }
         IEnumerable<string> GetAllTfsRootBranchesOrderedByCreation();
-        IEnumerable<IBranchObject> GetBranches();
+        IEnumerable<IBranchObject> GetBranches(bool getDeletedBranches = false);
         void EnsureAuthenticated();
         void CreateBranch(string sourcePath, string targetPath, int changesetId, string comment = null);
         void CreateTfsRootBranch(string projectName, string mainBranch, string gitRepositoryPath, bool createTeamProjectFolder);


### PR DESCRIPTION
Bug in Sep.Git.Tfs.Core.GitTfsRemote::FindOrInitTfsRemoteOfChangeset(..). Finding the remote repository for a parent changeset doesnt always work right. GetPathInGitRepo fails when I have 2 branches [$/Pete-3.1] and [$/Pete-3.1.1] because both start with "$/Pete-3.1" they will both be returned as matches. If the wrong repo is returned, searching for a specific commit will fail. This causes infinite loop. By adding slash at the end or something you can fix infinite loop problem
